### PR TITLE
Test, url, view for showing articles by author.

### DIFF
--- a/news_site/tests.py
+++ b/news_site/tests.py
@@ -1,19 +1,24 @@
-from news_site.models import NewsPost
+from news_site.models import NewsPost, Author
 from django.test import TestCase
 
 from django.core.validators import URLValidator
 from django.core.exceptions import ValidationError
 
 class NewsPostTestCase(TestCase):
+    def setUp(self):
+        self.author = Author.objects.create(first_name='Test', last_name='Author',
+                                            email='test@author.com')
+
     def create_news_post(self, title='Hello World', slug='hello-world',
                          content='Hello World, what more is there to say?',
-                         author='Test Author'):
+                         author=None):
         print("Creating Test NewsPost")
-        return NewsPost(title=title, slug=slug, content=content, author=author)
+        return NewsPost(title=title, slug=slug, content=content,
+                        author=self.author)
 
     def test_news_post_author_url(self):
         news_post = self.create_news_post()
-        url = '/articles/{0}'.format(news_post.author)
+        url = '/articles/{}'.format(news_post.author.id)
         print("Asserting Url Creation")
         print(url.replace(' ', '%'))
         response = self.client.get(url.replace(' ', '%'), follow=True)

--- a/news_site/urls.py
+++ b/news_site/urls.py
@@ -6,4 +6,6 @@ urlpatterns = [
     path('', views.home, name="author_info"),
     path('authors', views.author_general, name="author_general"),
     path('authors/<str:name>', views.author_about, name="author_info"),
+    path('articles/<int:author_id>', views.author_articles,
+         name="author_articles"),
     ]

--- a/news_site/views.py
+++ b/news_site/views.py
@@ -5,9 +5,16 @@ from django.http import Http404
 from django.template import Template
 from django.template.loader import get_template
 
+def author_articles(request, author_id):
+    author = Author.objects.get(id=author_id)
+    articles = NewsPost.objects.filter(author = author)
+    return render(request, 'home.html', {'page': 'author_articles',
+                                         'titles': articles})
+
 def author_about(request, name):
     articles = NewsPost.objects.filter(author__last_name = name)
-    return render(request, 'home.html' , {'page': 'author_about', 'titles': articles} )
+    return render(request, 'home.html' , {'page': 'author_about',
+                                          'titles': articles} )
 '''
 To Do: Find better naming conventions set up Author login and have it generate a
 test for this URL convention
@@ -16,7 +23,8 @@ def author_general(request):
     authors = Author.objects.all()
     if authors.count() == 0:
         raise Http404
-    return render(request, 'home.html', {'page': 'authors', 'authors_names': authors})
+    return render(request, 'home.html', {'page': 'authors',
+                                         'authors_names': authors})
 
 def home(request):
     return render(request, 'home.html', {'page': 'home'})


### PR DESCRIPTION
I changed the url pattern for articles to use author IDs in the
slug instead of author last names. Using last names for the slug
won't work if there are ever two authors with the same last name
in the system.